### PR TITLE
Remove svg wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,13 +32,13 @@ import svelteSVG from "rollup-plugin-svelte-svg";
 export default {
     client: {
         plugins: [
-            svelteSVG(),            
+            svelteSVG({ dev }),            
         ],
         ...
     },
     server: {
         plugins: [
-            svelteSVG({generate: "ssr"}),
+            svelteSVG({ generate: "ssr", dev }),
         ],
         ...
     }

--- a/src/index.js
+++ b/src/index.js
@@ -27,14 +27,14 @@ export default function svg(options = {}) {
 			const [, svgStart, svgBody] = svgRegex.exec(source);
 			const content = toSvelte(svgStart, svgBody);
 			const {
-				js: { code, map }
+				js: { code, map },
 			} = Svelte.compile(content, {
 				filename: id,
 				name: head(tail(id.split(isWindows ? "\\" : "/")).split(".")),
 				format: "esm",
 				generate: options.generate,
 				hydratable: true,
-				dev: options.dev
+				dev: options.dev,
 			});
 
 			return { code, map };

--- a/src/index.js
+++ b/src/index.js
@@ -23,8 +23,14 @@ export default function svg(options = {}) {
 			if (!filter(id) || extname(id) !== ".svg") {
 				return null;
 			}
-			const svgRegex = new RegExp("(<svg.*?)(\/?>.*)", "gs");
-			const [, svgStart, svgBody] = svgRegex.exec(source);
+			const svgRegex = new RegExp("(<svg.*?)(/?>.*)", "gs");
+			const parts = svgRegex.exec(source);
+			if (!parts) {
+				throw new Error(
+					"svg file did not start with <svg> tag. Unable to convert to Svelte component",
+				);
+			}
+			const [, svgStart, svgBody] = parts;
 			const content = toSvelte(svgStart, svgBody);
 			const {
 				js: { code, map },
@@ -38,6 +44,6 @@ export default function svg(options = {}) {
 			});
 
 			return { code, map };
-		}
+		},
 	};
 }

--- a/src/index.js
+++ b/src/index.js
@@ -23,7 +23,7 @@ export default function svg(options = {}) {
 			if (!filter(id) || extname(id) !== ".svg") {
 				return null;
 			}
-			const svgRegex = new RegExp("(<svg.+?)(>.+)", "gs");
+			const svgRegex = new RegExp("(<svg.*?)(\/?>.*)", "gs");
 			const [, svgStart, svgBody] = svgRegex.exec(source);
 			const content = toSvelte(svgStart, svgBody);
 			const {


### PR DESCRIPTION
Modified approach to create svelte component.

I use regular expression to split svg into two parts (<svg..... ) and (>....</svg>).
After that I'm using $$props to pass all props to the svg.

As result we are getting clean svg without wrapper with all passed properties.