### PR TITLE
fix https://github.com/codefeathers/rollup-plugin-svelte-svg/issues/18

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -37,6 +37,7 @@ export default function svg(options = {}) {
 			if (!filter(id) || extname(id) !== ".svg") {
 				return null;
 			}
+			source=decodeURIComponent(source);
 			const svgRegex = new RegExp("(<svg.*?)(/?>.*)", "gs");
 			const parts = svgRegex.exec(source);
 			if (!parts) {


### PR DESCRIPTION
in latest versions of rollup svg content is encoded. To avoid that added `decodeURIComponent(source);`