### PR TITLE
Adding <title> slot for accessibility with screen readers

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ function addProps(source) {
 	if (!parts) throw new Error("Unable to parse as svg.");
 
 	const [, svgStart, end, svgBody] = parts;
-	return `${svgStart} role="img" {...$$props} ${end}<title><slot></slot></title>${svgBody}`;
+	return `${svgStart} role="img" {...$$props} ${end}<slot/>${svgBody}`;
 }
 
 const SVELTE_EXT = ".rollup-plugin.svelte";

--- a/index.js
+++ b/index.js
@@ -4,15 +4,15 @@ const { readFile } = require("fs").promises;
 const { optimize: optimise } = require("svgo");
 const { createFilter } = require("rollup-pluginutils");
 
-const svgRegex = /(<svg.*?)(>.*)/s;
+const svgRegex = /(<svg.*?)(>)(.*)/s;
 const svgheader = /^\<\?xml.+?\>/;
 
 function addProps(source) {
 	const parts = svgRegex.exec(source);
 	if (!parts) throw new Error("Unable to parse as svg.");
 
-	const [, svgStart, svgBody] = parts;
-	return `${svgStart} {...$$props} ${svgBody}`;
+	const [, svgStart, end, svgBody] = parts;
+	return `${svgStart} role="img" {...$$props} ${end}<title><slot></slot></title>${svgBody}`;
 }
 
 const SVELTE_EXT = ".rollup-plugin.svelte";


### PR DESCRIPTION
For my own purposes, I wanted to support screen readers. I'm not 100% confident on the best way to do so, but this seemed to be the most simple implementation that will allow me to inject something like: `<title>Screen Reader Text</title>` into my SVGs.

Usage example:

```
<PieChart fill="red">
This is some alt text for screen readers
</PieChart>
```

Result:
```
<svg fill="red ... >
   <title>This is some alt text for screen readers</title>
   ... svg contents ...
</svg>
```

It might make more sense to implement a `<slot="title">` and `<slot="desc">` for the purposes of your library but I only needed `<title>`

You also might look into implementing `aria-labelledby=` and generating a GUID but this was way outside the scope of my needs. 

For reference, https://www.deque.com/blog/creating-accessible-svgs/ discusses the various options for accessibility with `<svg>` icons 